### PR TITLE
feat: enhance item fetching & caching logic

### DIFF
--- a/app/items/[id]/item-editable-client.tsx
+++ b/app/items/[id]/item-editable-client.tsx
@@ -27,7 +27,7 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { redirect, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useItemEditable } from "@/lib/hooks/use-item-editable";
 import { Combobox } from "@/components/ui/combo-box";
 import { LOCATION_MAP, LocationKey } from "@/lib/constants/locations";

--- a/app/items/items-grid-client.tsx
+++ b/app/items/items-grid-client.tsx
@@ -1,75 +1,117 @@
 "use client"
 
-import { useState, useMemo, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { ItemCard } from '@/components/item-card';
 import { Search, Filter, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import useSWRInfinite from 'swr/infinite';
 import { getPaginatedItems } from '@/lib/api/swr-items';
-import { fetchData } from '@/lib/utils/swrHelper';
 import { formatDate } from '@/lib/date-formatting';
 import { ItemsGridSkeleton } from './items-loading-skeleton';
 import { useDebouncedValue } from '@/lib/hooks/useDebounce';
 
-export function ItemsGridClient() {
+// Build a query string for a given page index and current filter values.
+// Passed as explicit arguments so both the initial-load effect and the
+// loadMore callback always use whichever values are current at call time.
+function buildQueryString(
+    page: number,
+    search: string,
+    category: string,
+    type: string
+): string {
+    const params = new URLSearchParams({ page: page.toString(), limit: '12' });
+    if (search) params.set('search', search);
+    if (category !== 'all') params.set('category', category);
+    if (type !== 'all') params.set('item_type', type);
+    return params.toString();
+}
+
+export function ItemsGridClient({ segment }: { segment: "public" | "boys" | "girls" }) {
     const [searchInput, setSearchInput] = useState('');
     const [categoryFilter, setCategoryFilter] = useState('all');
     const [activeTab, setActiveTab] = useState<'all' | 'found' | 'lost'>('all');
     const loadMoreRef = useRef<HTMLDivElement>(null);
 
-    // Debounce search to reduce API calls
+    // Core feed state — items are stored already formatted so no downstream
+    // memoization is required.
+    const [allItems, setAllItems] = useState<ReturnType<typeof formatDate>[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isLoadingMore, setIsLoadingMore] = useState(false);
+    const [hasMore, setHasMore] = useState(false);
+
+    // Refs prevent stale closures inside the IntersectionObserver callback
+    // without forcing the observer effect to re-run on every state update.
+    const nextPageRef = useRef(2);
+    const loadingMoreRef = useRef(false);
+    const hasMoreRef = useRef(false);
+
+    // Debounce search to reduce server action invocations
     const searchQuery = useDebouncedValue(searchInput, 400);
     const typeFilter = activeTab === 'all' ? 'all' : activeTab;
 
-    function getKey(pageIndex: number, previousPageData: any) {
-        if (previousPageData && !previousPageData.has_more) return null;
+    // Reload from page 1 whenever any filter changes.
+    // The Next.js Data Cache (revalidate: 120, tagged per segment) handles
+    // deduplication and freshness; no client cache is needed here.
+    useEffect(() => {
+        let cancelled = false;
 
-        const params = new URLSearchParams({
-            page: (pageIndex + 1).toString(),
-            limit: '12',
-        });
+        setIsLoading(true);
+        setAllItems([]);
+        setHasMore(false);
+        hasMoreRef.current = false;
+        nextPageRef.current = 2; // next incremental page after the first load
 
-        if (searchQuery) params.set('search', searchQuery);
-        if (categoryFilter !== 'all') params.set('category', categoryFilter);
-        if (typeFilter !== 'all') params.set('item_type', typeFilter);
+        getPaginatedItems(segment, buildQueryString(1, searchQuery, categoryFilter, typeFilter))
+            .then((result) => {
+                if (cancelled) return;
+                if (result.ok && result.data) {
+                    setAllItems(result.data.items.map(formatDate));
+                    setHasMore(result.data.has_more);
+                    hasMoreRef.current = result.data.has_more;
+                }
+                setIsLoading(false);
+            });
 
-        return params.toString();
-    }
+        return () => { cancelled = true; };
+    }, [searchQuery, categoryFilter, typeFilter, segment]);
 
-    const { data, size, setSize, isLoading, isValidating } = useSWRInfinite(
-        getKey,
-        async function (queryString) {
-            const result = await fetchData(() => getPaginatedItems(queryString));
-            return result;
-        },
-        {
-            revalidateAll: false,
+    // Load the next page and append its items to the existing list.
+    // Guards via refs ensure only one concurrent load at a time.
+    const loadMore = useCallback(async () => {
+        if (loadingMoreRef.current || !hasMoreRef.current) return;
+
+        loadingMoreRef.current = true;
+        setIsLoadingMore(true);
+
+        const page = nextPageRef.current;
+        const result = await getPaginatedItems(
+            segment,
+            buildQueryString(page, searchQuery, categoryFilter, typeFilter)
+        );
+
+        if (result.ok && result.data) {
+            setAllItems(prev => [...prev, ...result.data!.items.map(formatDate)]);
+            setHasMore(result.data.has_more);
+            hasMoreRef.current = result.data.has_more;
+            nextPageRef.current = page + 1;
         }
-    );
 
-    // Reset pagination when filters change
+        loadingMoreRef.current = false;
+        setIsLoadingMore(false);
+    }, [searchQuery, categoryFilter, typeFilter, segment]);
+
+    // Infinite scroll observer — reconnects whenever hasMore, isLoadingMore,
+    // or loadMore (filter set) changes.  When a filter change resets hasMore
+    // to false the observer is not attached, preventing spurious page loads.
     useEffect(() => {
-        setSize(1);
-    }, [searchQuery, categoryFilter, typeFilter, setSize]);
-
-    const allItems = useMemo(() => {
-        if (!data) return [];
-        return data.flatMap(page => page.items.map(formatDate));
-    }, [data]);
-
-    const hasMore = data?.[data.length - 1]?.has_more ?? false;
-
-    // Infinite scroll observer
-    useEffect(() => {
-        if (!loadMoreRef.current || !hasMore || isValidating) return;
+        if (!loadMoreRef.current || !hasMore || isLoadingMore) return;
 
         const observer = new IntersectionObserver(
             (entries) => {
-                if (entries[0].isIntersecting && hasMore && !isValidating) {
-                    setSize(size + 1);
+                if (entries[0].isIntersecting) {
+                    loadMore();
                 }
             },
             { rootMargin: '150px' }
@@ -77,7 +119,7 @@ export function ItemsGridClient() {
 
         observer.observe(loadMoreRef.current);
         return () => observer.disconnect();
-    }, [hasMore, isValidating, setSize, size]);
+    }, [hasMore, isLoadingMore, loadMore]);
 
     return (
         <>

--- a/app/items/page.tsx
+++ b/app/items/page.tsx
@@ -1,7 +1,12 @@
+import { auth } from '@/lib/auth';
 import { ItemsGridClient } from './items-grid-client';
 
 
 export default async function BrowseItemsPage() {
+    const session = await auth();
+
+    const segment = session?.user?.hostel === "boys" ? "boys" : session?.user?.hostel === "girls" ? "girls" : "public";
+
     return (
         <div className="container mx-auto px-4 py-8 min-h-[calc(100vh-4rem)]">
             <div className="flex flex-col gap-6 mb-8">
@@ -15,7 +20,7 @@ export default async function BrowseItemsPage() {
                 </div>
             </div>
 
-            <ItemsGridClient />
+            <ItemsGridClient segment={segment} />
         </div >
     );
 }

--- a/app/report/item-form-client.tsx
+++ b/app/report/item-form-client.tsx
@@ -159,7 +159,7 @@ export function ItemFormClient({ session, type }: ItemFormClientProps) {
 
             toast.success("Item reported successfully!");
 
-            router.push(`/items/${res.data}`);
+            router.push(`/items/${res.data.item_id}`);
         } catch (error) {
             console.error(error);
             toast.error("Something went wrong. Please try again.");

--- a/lib/api/admin.ts
+++ b/lib/api/admin.ts
@@ -10,6 +10,8 @@ import {
     ModerateItemRequest,
 } from "@/types/admin";
 import { authFetch, safeJson, UnauthorizedError } from "./helpers";
+import { revalidateFeedByVisibility } from "../utils/revalidateFeed";
+import { updateTag } from "next/cache";
 
 export async function getStats() {
     try {
@@ -136,12 +138,12 @@ export async function getReportedItems(limit = 50, skip = 0) {
     }
 }
 
-export async function moderateItem(itemId: string, action: ModerateItemRequest) {
+export async function moderateItem(itemId: string, request: ModerateItemRequest) {
     try {
         const res = await authFetch(`/admin/items/${itemId}/moderate`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(action),
+            body: JSON.stringify(request),
         });
 
         if (!res.ok) {
@@ -149,7 +151,12 @@ export async function moderateItem(itemId: string, action: ModerateItemRequest) 
             return { ok: false, status: res.status };
         }
 
-        return { ok: true, data: await safeJson(res) };
+        const result = await safeJson(res);
+
+        updateTag(`item-${itemId}`); // Invalidate cache for this item
+        revalidateFeedByVisibility(result.visibility); // Revalidate the feed based on the item's visibility
+
+        return { ok: true, data: result };
     } catch (err) {
         if (err instanceof UnauthorizedError) throw err;
 

--- a/lib/api/authenticated-api.ts
+++ b/lib/api/authenticated-api.ts
@@ -2,7 +2,8 @@
 
 import { OnboardingPayload } from "@/types/user";
 import { authFetch, safeJson, UnauthorizedError } from "./helpers";
-import { revalidatePath, revalidateTag, updateTag } from "next/cache";
+import { updateTag } from "next/cache";
+import { revalidateFeedByVisibility } from "../utils/revalidateFeed";
 
 // POST: Lost or Found Item
 export async function postLostFoundItem(formData: FormData) {
@@ -17,7 +18,10 @@ export async function postLostFoundItem(formData: FormData) {
             return { ok: false, status: res.status };
         }
 
-        return { ok: true, data: await safeJson(res) };
+        const result = await safeJson(res);
+        revalidateFeedByVisibility(result.visibility); // Revalidate the feed based on the item's visibility
+
+        return { ok: true, data: result };
     } catch (err) {
         if (err instanceof UnauthorizedError) throw err;
 
@@ -40,9 +44,19 @@ export async function updateItem(itemId: string, data: Record<string, any>) {
             return { ok: false, status: res.status };
         }
 
+        const result = await safeJson(res);
+
         updateTag(`item-${itemId}`); // Invalidate cache for this item
 
-        return { ok: true, data: await safeJson(res) };
+        // If visibility changed, we need to revalidate the relevant feeds
+        if (result.visibility_changed) {
+            revalidateFeedByVisibility(result.old_visibility);
+            revalidateFeedByVisibility(result.new_visibility);
+        } else {
+            revalidateFeedByVisibility(result.old_visibility);
+        }
+
+        return { ok: true, data: result };
     } catch (err) {
         if (err instanceof UnauthorizedError) throw err;
 
@@ -63,7 +77,11 @@ export async function deleteItem(itemId: string) {
             return { ok: false, status: res.status };
         }
 
+        const result = await safeJson(res);
+
         updateTag(`item-${itemId}`); // Invalidate cache for this item
+
+        revalidateFeedByVisibility(result.visibility); // Revalidate the feed based on the item's visibility
 
         return { ok: true };
     } catch (err) {

--- a/lib/api/swr-items.ts
+++ b/lib/api/swr-items.ts
@@ -4,19 +4,30 @@ import { auth } from "@/lib/auth";
 import { authFetch, publicFetch, safeJson, UnauthorizedError } from "./helpers";
 import { Item } from "@/types/item";
 
-// GET: Paginated Items (works with or without authentication)
-export async function getPaginatedItems(queryString: string = '') {
+// GET: Paginated Items (supports search, category, and type filters)
+// If 'search' is in query, bypass cache to ensure fresh results. Otherwise, cache for 2 minutes.
+export async function getPaginatedItems(
+    segment: "public" | "boys" | "girls",
+    queryString: string = ""
+) {
     try {
-        const session = await auth();
-        const token = session?.backendToken;
+        const hasSearch = queryString.includes("search=");
 
-        const url = queryString ? `/items/all?${queryString}` : '/items/all?page=1&limit=12';
+        const url = queryString
+            ? `/items/all?segment=${segment}&${queryString}`
+            : `/items/all?segment=${segment}&page=1&limit=12`;
 
-        const res = await publicFetch(url, {
-            headers: {
-                ...(token ? { Authorization: `Bearer ${token}` } : {}),
-            },
-            cache: 'no-store',
+        const res = await publicFetch(
+            url, {
+            ...(hasSearch
+                ? { cache: "no-store" }
+                : {
+                    next: {
+                        revalidate: 120,
+                        tags: [`items-${segment}`],
+                    },
+                }
+            )
         });
 
         if (!res.ok) {

--- a/lib/hooks/use-item-editable.ts
+++ b/lib/hooks/use-item-editable.ts
@@ -33,10 +33,10 @@ export function useItemEditable({ item, reporter, resolution_status, session }: 
     const [resolutionStatus, setResolutionStatus] = useState(resolution_status);
 
     const [formData, setFormData] = useState({
-        title: item.title ?? "",
-        location: item.location ?? "",
-        description: item.description ?? "",
-        category: item.category ?? "",
+        title: item.title,
+        location: item.location,
+        description: item.description,
+        category: item.category,
         visibility: item.visibility ?? "public",
         date: item.date ? new Date(item.date).toISOString().slice(0, 10) : "",
     });
@@ -78,7 +78,7 @@ export function useItemEditable({ item, reporter, resolution_status, session }: 
                 const oldDate = new Date(item.date).toISOString().slice(0, 10);
 
                 if (newDate !== oldDate) {
-                    updates.date = new Date(newValue).toISOString();
+                    updates['date'] = new Date(newValue).toISOString();
                     hasChanges = true;
                 }
 

--- a/lib/utils/revalidateFeed.ts
+++ b/lib/utils/revalidateFeed.ts
@@ -1,0 +1,13 @@
+"use server";
+
+import { revalidateTag } from "next/cache";
+
+export async function revalidateFeedByVisibility(visibility: "public" | "boys" | "girls") {
+    if (visibility === "public") {
+        revalidateTag("items-public", "max");
+        revalidateTag("items-boys", "max");
+        revalidateTag("items-girls", "max");
+    } else {
+        revalidateTag(`items-${visibility}`, "max");
+    }
+}

--- a/types/admin.ts
+++ b/types/admin.ts
@@ -65,7 +65,7 @@ export interface UserDetail {
 export interface ReportedItemDetail {
     id: string;
     title: string;
-    visibility: string;
+    visibility: "public" | "boys" | "girls";
     owner_name: string;
     report_count: number;
     is_hidden: boolean;
@@ -80,26 +80,6 @@ export interface ReportDetail {
     reason: string;
     created_at: string;
     status: string;
-}
-
-export interface InsightData {
-    most_reported_items: Array<{
-        item_id: string;
-        title: string;
-        report_count: number;
-    }>;
-    most_reported_users: Array<{
-        user_id: string;
-        name: string;
-        report_count: number;
-    }>;
-    claim_success_rate: number;
-    avg_claim_resolution_time_hours: number | null;
-    items_by_category: Array<{
-        category: string;
-        count: number;
-    }>;
-    claims_by_status: Record<string, number>;
 }
 
 export interface ModerateUserRequest {


### PR DESCRIPTION
- includes segment support
- api calls revalidate based on data from backend instead of client-side
- *all pages of browse feed are cached*
- browse feed is revalidated when item is created, updated or deleted
- admin moderations also revalidate the cache
- SWR is completely removed from feed page
- getPaginatedItems doesn't pass auth token to backend
- the user hostel is directly inferred from NextAuth session cookie